### PR TITLE
docs: update ROADMAP baseline from v1.4.0 to v1.6.2

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,14 +13,12 @@
 
 ## Current Baseline — v1.6.2
 
-- Stable sync DB-API surface
-- Native asyncio API (`pycubrid.aio`) shipped in v1.1.0
-- JSON / collection decoding, `ping()`, and `nextset()` shipped in v1.2.0
-- Sync TLS shipped in v1.3.0
-- Async TLS and TLS 1.2 minimum baseline shipped in v1.4.0
-- 1.x release policy with an automated `compat-check` CI gate against `api-baseline.json` shipped in v1.5.0
-- Python 3.10 async-TLS preflight verification probe shipped in v1.5.0
-- Python 3.14 support validated in CI as of the current v1.6.2 baseline
+- Stable sync DB-API 2.0 surface plus native asyncio API (`pycubrid.aio`)
+- JSON / collection decoding, `ping()`, `nextset()`, and sync + async TLS (TLS 1.2 minimum)
+- 1.x release policy enforced by an automated `compat-check` CI gate against `api-baseline.json`
+- Supported runtimes: Python 3.10–3.14, CUBRID 10.2–11.4
+
+_See **Completed** for the per-release milestone history._
 
 ## Future
 
@@ -33,6 +31,11 @@
 Python 3.10+, CUBRID 10.2–11.4
 
 ## Completed
+
+### Release Policy & Runtime Coverage (v1.5.0 / v1.6.2)
+- 1.x release policy with an automated `compat-check` CI gate against `api-baseline.json` (v1.5.0)
+- Python 3.10 async-TLS preflight verification probe (v1.5.0)
+- Python 3.14 support validated in CI (v1.6.2 baseline)
 
 ### Type Safety & Protocol (v1.2.0)
 - Native `Connection.ping()` via CHECK_CAS (FC=32)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-> **Last updated**: 2026-05-15
+> **Last updated**: 2026-08-24
 >
 > This roadmap reflects current priorities. For the ecosystem-wide view, see the
 > [CUBRID Labs Ecosystem Roadmap](https://github.com/cubrid-lab/.github/blob/main/ROADMAP.md).
@@ -11,13 +11,16 @@
 - 🗂️ [Org Project Board](https://github.com/orgs/cubrid-lab/projects/2)
 - 🌐 [Ecosystem Roadmap](https://github.com/cubrid-lab/.github/blob/main/ROADMAP.md)
 
-## Current Baseline — v1.4.0
+## Current Baseline — v1.6.2
 
 - Stable sync DB-API surface
 - Native asyncio API (`pycubrid.aio`) shipped in v1.1.0
 - JSON / collection decoding, `ping()`, and `nextset()` shipped in v1.2.0
 - Sync TLS shipped in v1.3.0
 - Async TLS and TLS 1.2 minimum baseline shipped in v1.4.0
+- 1.x release policy with an automated `compat-check` CI gate against `api-baseline.json` shipped in v1.5.0
+- Python 3.10 async-TLS preflight verification probe shipped in v1.5.0
+- Python 3.14 support validated in CI as of the current v1.6.2 baseline
 
 ## Future
 


### PR DESCRIPTION
Closes #253.

## Summary
`ROADMAP.md` claimed "Current Baseline — v1.4.0" (last updated 2026-05-15), but the shipped version is **1.6.2** (`pycubrid/__init__.py`; PyPI 1.6.2 uploaded 2026-08-06, declaring Python 3.10–3.14 classifiers — confirmed via the PyPI JSON API).

- Bumped baseline heading v1.4.0 → **v1.6.2** and refreshed the date.
- Added the shipped 1.5.x milestones that are corroborated by the README (`compat-check` CI gate vs `api-baseline.json`; Python 3.10 async-TLS preflight probe) and the 3.14 CI support of the current baseline.

Scope kept to verifiable facts; no unverifiable changelog content invented.

**Do not merge** — opened for review per request.