### PR TITLE
fix: auto-negotiate backslash-escape mode to prevent silent string corruption (#255)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+- **Backslash-escape mode is now auto-negotiated from the server, fixing silent string corruption (#255)** — CUBRID's `no_backslash_escapes` system parameter defaults to `yes` (a backslash is an ordinary literal character), but pycubrid defaulted its client-side flag to `False` and unconditionally doubled backslashes. Against a stock server this silently corrupted data: `C:\temp\file` (12 chars) was stored as `C:\\temp\\file` (14 chars), and `regex \d+` became `regex \\d+`. `Connection`/`AsyncConnection` now probe the live server once at connect time with `SELECT CHAR_LENGTH('\\')` when `no_backslash_escapes` is not passed explicitly: a result of `2` selects literal mode (`True`, no doubling), `1` selects escape-processing mode (`False`), and any other value or probe error falls back to the legacy `False` with a logged warning so detection never breaks `connect()`. Passing `no_backslash_escapes=True|False` explicitly skips the probe. LIKE metacharacters (`%`, `_`) were never escaped and remain untouched. See [docs/PARAMETER_BINDING.md](docs/PARAMETER_BINDING.md#escape-mode-negotiation).
+
 ### Changed
 - **Ruff lint rule selection now declared explicitly (#247)** — `pyproject.toml` configured ruff but never set `[tool.ruff.lint] select`, so `ruff check` inherited ruff's implicit defaults. Ruff expanded that default set in 0.16 (59 → 413 rules against this repo's config), which is why #245 (`0.15.22 → 0.16.1`) failed lint with 237 errors in untouched code. Pinning the ruff *version* in #236 stopped unpinned installs from drifting, but could not survive the bump itself — the rule set is now pinned too, via `select = ["E4", "E7", "E9", "F"]`, which is exactly what ruff selected by default through 0.15.x (same 59 rules under both versions).
 

--- a/docs/PARAMETER_BINDING.md
+++ b/docs/PARAMETER_BINDING.md
@@ -17,8 +17,9 @@ change to the rules below is a contract change governed by
 - [Placeholder Style](#placeholder-style)
 - [Type Mapping (Guarantees)](#type-mapping-guarantees)
 - [String Escaping](#string-escaping)
-  - [Default mode](#default-mode)
-  - [`no_backslash_escapes` mode](#no_backslash_escapes-mode)
+  - [Escape-mode negotiation](#escape-mode-negotiation)
+  - [Literal mode](#literal-mode-no_backslash_escapestrue)
+  - [Escape-processing mode](#escape-processing-mode-no_backslash_escapesfalse)
 - [Placeholder Tokenizer](#placeholder-tokenizer)
 - [`executemany`](#executemany)
 - [Non-Guarantees and Explicit Limits](#non-guarantees-and-explicit-limits)
@@ -119,10 +120,12 @@ test that pins the behavior.
 ## String Escaping
 
 String escaping is performed by `escape_string`
-(`pycubrid/_cursor_common.py:124-138`). The behavior depends on the
+(`pycubrid/_cursor_common.py`). The behavior depends on the
 `no_backslash_escapes` connection flag
-(`pycubrid/_connection_common.py:57-87`, set via
-`pycubrid.connect(..., no_backslash_escapes=True)`).
+(`pycubrid/_connection_common.py`). By default the flag is **auto-negotiated**
+from the live server at connect time (see
+[Escape-mode negotiation](#escape-mode-negotiation)); pass it explicitly to
+`pycubrid.connect(..., no_backslash_escapes=True|False)` to override detection.
 
 In every mode:
 
@@ -137,9 +140,51 @@ In every mode:
   (`tests/test_param_security.py::TestEscapeString::test_unicode_passthrough`,
   `::test_unicode_non_bmp_passthrough`).
 
-### Default mode
+### Escape-mode negotiation
 
-`no_backslash_escapes=False` (the default):
+CUBRID's `no_backslash_escapes` **system parameter defaults to `yes`** — a
+backslash is an ordinary literal character, not an escape marker
+([CUBRID manual, literal.rst](https://github.com/CUBRID/cubrid-manual/blob/master/en/sql/literal.rst):
+*"An escape using a backslash can be used if you set no_backslash_escapes in
+cubrid.conf as no. But this default value is yes."*). If the driver blindly
+doubled backslashes against such a server, `C:\temp\file` would be stored as
+`C:\\temp\\file` — silent data corruption (issue #255).
+
+To stay correct against whatever the server is actually configured for, when
+`no_backslash_escapes` is **not** passed to `connect()`, the driver probes the
+live server once at connect time with `SELECT CHAR_LENGTH('\\')` (the SQL
+literal `'\\'`, two backslash characters):
+
+- result `2` → the server left both backslashes intact → **literal mode**, so
+  the driver pins `no_backslash_escapes=True` (does NOT double backslashes).
+- result `1` → the server unescaped the pair → **escape-processing mode**, so
+  the driver pins `no_backslash_escapes=False`.
+- any other value or a probe error → falls back to `no_backslash_escapes=False`
+  (legacy behavior) and logs a warning, so detection never breaks `connect()`.
+
+Passing `no_backslash_escapes=True` or `False` explicitly skips the probe
+entirely. Negotiation happens once per physical connection and is preserved
+across transparent reconnects.
+
+### Literal mode (`no_backslash_escapes=True`)
+
+This is what auto-negotiation selects against a stock CUBRID server
+(`no_backslash_escapes=yes`):
+
+1. Single quotes are doubled (`'` → `''`).
+2. Backslashes and control characters are **left untouched** (the server
+   treats them as ordinary characters, so they round-trip byte-for-byte).
+3. NUL rejection still applies.
+4. The result is wrapped in single quotes.
+
+Pinned by `tests/test_aio_cursor_parity.py:99-105`,
+`tests/test_backslash_negotiation.py`, and the live round-trip suite
+`tests/test_integration.py::TestBackslashRoundTrip`.
+
+### Escape-processing mode (`no_backslash_escapes=False`)
+
+Selected when the server runs `no_backslash_escapes=no`, or when pinned
+explicitly. The driver doubles backslashes so the server unescapes them back:
 
 1. Backslashes are doubled (`\` → `\\`).
 2. Single quotes are doubled (`'` → `''`).
@@ -149,20 +194,6 @@ In every mode:
 
 Pinned by `tests/test_param_security.py:27-55` and
 `tests/test_aio_cursor_parity.py:87-96`.
-
-### `no_backslash_escapes` mode
-
-When the connection is created with `no_backslash_escapes=True`:
-
-1. Single quotes are doubled (`'` → `''`).
-2. Backslashes and control characters are **left untouched**.
-3. NUL rejection still applies.
-4. The result is wrapped in single quotes.
-
-Pinned by `tests/test_aio_cursor_parity.py:99-105`.
-
-This mode exists for compatibility with CUBRID server configurations where the
-server itself does not treat `\` as a string-escape character.
 
 ---
 

--- a/pycubrid/_connection_common.py
+++ b/pycubrid/_connection_common.py
@@ -68,7 +68,7 @@ class ConnectionCommonMixin:
         read_timeout: float | None = None,
         decode_collections: bool = False,
         json_deserializer: Any = None,
-        no_backslash_escapes: bool = False,
+        no_backslash_escapes: bool | None = None,
         enable_timing: bool | None = None,
     ) -> None:
         """Initialise attributes common to sync and async connections."""
@@ -81,7 +81,7 @@ class ConnectionCommonMixin:
         self._read_timeout = read_timeout
         self._decode_collections = decode_collections
         self._json_deserializer = json_deserializer
-        self._no_backslash_escapes = no_backslash_escapes
+        self._no_backslash_escapes: bool | None = no_backslash_escapes
 
         if type(fetch_size) is not int or fetch_size < 1:
             raise ValueError("fetch_size must be an integer >= 1")

--- a/pycubrid/aio/connection.py
+++ b/pycubrid/aio/connection.py
@@ -86,7 +86,7 @@ class AsyncConnection(ConnectionCommonMixin):
             read_timeout=kwargs.get("read_timeout"),
             decode_collections=kwargs.get("decode_collections", False),
             json_deserializer=kwargs.get("json_deserializer"),
-            no_backslash_escapes=kwargs.get("no_backslash_escapes", False),
+            no_backslash_escapes=kwargs.get("no_backslash_escapes", None),
             enable_timing=kwargs.get("enable_timing"),
         )
         self._reader: asyncio.StreamReader | None = None
@@ -120,6 +120,54 @@ class AsyncConnection(ConnectionCommonMixin):
             await self._connect_locked()
             if did_connect and self._pending_autocommit:
                 await self._apply_pending_autocommit_locked()
+        # Negotiate the backslash-escape mode outside the lock: it issues a
+        # regular query round-trip via a cursor, and the guard keeps it to a
+        # single probe across transparent reconnects.
+        if self._no_backslash_escapes is None:
+            await self._negotiate_backslash_escapes()
+
+    async def _negotiate_backslash_escapes(self) -> None:
+        """Async counterpart of
+        :meth:`pycubrid.connection.Connection._negotiate_backslash_escapes`.
+
+        Probes the live server with ``SELECT CHAR_LENGTH('\\')`` and pins
+        ``self._no_backslash_escapes`` to ``True`` (literal mode, the CUBRID
+        default), ``False`` (backslash-escape processing on), or the legacy
+        ``False`` with a warning if detection fails.
+        """
+        if self._no_backslash_escapes is not None:
+            return
+        try:
+            cursor = self.cursor()
+            try:
+                await cursor.execute("SELECT CHAR_LENGTH('\\\\')")
+                row = await cursor.fetchone()
+            finally:
+                await cursor.close()
+        except Exception as exc:  # noqa: BLE001 — detection must never break connect
+            self._no_backslash_escapes = False
+            _LOGGER.warning(
+                "Failed to detect CUBRID backslash-escape mode (%s); "
+                "falling back to no_backslash_escapes=False (legacy "
+                "behaviour). Pass no_backslash_escapes explicitly to "
+                "silence this warning.",
+                exc,
+            )
+            return
+        length = row[0] if row else None
+        if length == 2:
+            self._no_backslash_escapes = True
+        elif length == 1:
+            self._no_backslash_escapes = False
+        else:
+            self._no_backslash_escapes = False
+            _LOGGER.warning(
+                "Could not detect CUBRID backslash-escape mode "
+                "(CHAR_LENGTH probe returned %r); falling back to "
+                "no_backslash_escapes=False (legacy behaviour). Pass "
+                "no_backslash_escapes explicitly to silence this warning.",
+                length,
+            )
 
     async def _connect_locked(self) -> None:
         if self._connected:

--- a/pycubrid/connection.py
+++ b/pycubrid/connection.py
@@ -64,13 +64,65 @@ class Connection(ConnectionCommonMixin):
             read_timeout=kwargs.get("read_timeout"),
             decode_collections=decode_collections,
             json_deserializer=json_deserializer,
-            no_backslash_escapes=kwargs.get("no_backslash_escapes", False),
+            no_backslash_escapes=kwargs.get("no_backslash_escapes", None),
             enable_timing=kwargs.get("enable_timing"),
         )
 
         self.connect()
+        self._negotiate_backslash_escapes()
         if autocommit:
             self.autocommit = True
+
+    def _negotiate_backslash_escapes(self) -> None:
+        """Detect the server's backslash-escape mode when not pinned.
+
+        CUBRID's ``no_backslash_escapes`` system parameter defaults to
+        ``yes``: a backslash is an ordinary literal character, not an
+        escape marker.  When the caller has not set ``no_backslash_escapes``
+        explicitly, probe the live server with ``SELECT CHAR_LENGTH('\\')``
+        (the SQL literal ``'\\'`` — two backslash characters):
+
+        * result ``2`` — literal mode (the server default); the driver must
+          NOT double backslashes, so ``self._no_backslash_escapes`` is
+          ``True``.
+        * result ``1`` — the server unescaped the pair, i.e. backslash-escape
+          processing is on, so ``self._no_backslash_escapes`` is ``False``.
+        * any other value or any error — fall back to the legacy ``False``
+          and warn, so a detection failure never breaks ``connect()``.
+        """
+        if self._no_backslash_escapes is not None:
+            return
+        try:
+            cursor = self.cursor()
+            try:
+                cursor.execute("SELECT CHAR_LENGTH('\\\\')")
+                row = cursor.fetchone()
+            finally:
+                cursor.close()
+        except Exception as exc:  # noqa: BLE001 — detection must never break connect
+            self._no_backslash_escapes = False
+            _LOGGER.warning(
+                "Failed to detect CUBRID backslash-escape mode (%s); "
+                "falling back to no_backslash_escapes=False (legacy "
+                "behaviour). Pass no_backslash_escapes explicitly to "
+                "silence this warning.",
+                exc,
+            )
+            return
+        length = row[0] if row else None
+        if length == 2:
+            self._no_backslash_escapes = True
+        elif length == 1:
+            self._no_backslash_escapes = False
+        else:
+            self._no_backslash_escapes = False
+            _LOGGER.warning(
+                "Could not detect CUBRID backslash-escape mode "
+                "(CHAR_LENGTH probe returned %r); falling back to "
+                "no_backslash_escapes=False (legacy behaviour). Pass "
+                "no_backslash_escapes explicitly to silence this warning.",
+                length,
+            )
 
     def connect(self) -> None:
         """Establish a TCP CAS session with broker handshake and open database.

--- a/tests/test_backslash_negotiation.py
+++ b/tests/test_backslash_negotiation.py
@@ -1,0 +1,133 @@
+"""Tests for automatic backslash-escape mode negotiation (issue #255).
+
+CUBRID's ``no_backslash_escapes`` system parameter defaults to ``yes``
+(a backslash is an ordinary literal character).  When the caller does not
+pin the mode explicitly, the driver probes the live server with
+``SELECT CHAR_LENGTH('\\\\')`` and derives the correct client-side escaping
+behaviour, avoiding the silent doubling of backslashes.
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pycubrid.aio.connection import AsyncConnection
+from pycubrid.connection import Connection
+
+
+def _make_sync_conn(
+    fetchone_result: object,
+    *,
+    preset: bool | None = None,
+    raise_on_execute: bool = False,
+) -> tuple[Connection, MagicMock]:
+    conn = Connection.__new__(Connection)
+    conn._no_backslash_escapes = preset
+    mock_cursor = MagicMock()
+    if raise_on_execute:
+        mock_cursor.execute.side_effect = RuntimeError("boom")
+    mock_cursor.fetchone.return_value = fetchone_result
+    conn.cursor = MagicMock(return_value=mock_cursor)  # type: ignore[method-assign]
+    return conn, mock_cursor
+
+
+class TestSyncNegotiation:
+    def test_probe_two_means_literal_mode(self) -> None:
+        conn, cur = _make_sync_conn((2,))
+        conn._negotiate_backslash_escapes()
+        assert conn._no_backslash_escapes is True
+        cur.execute.assert_called_once_with("SELECT CHAR_LENGTH('\\\\')")
+
+    def test_probe_one_means_escape_mode(self) -> None:
+        conn, _ = _make_sync_conn((1,))
+        conn._negotiate_backslash_escapes()
+        assert conn._no_backslash_escapes is False
+
+    def test_probe_unexpected_falls_back_false_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        conn, _ = _make_sync_conn((7,))
+        with caplog.at_level(logging.WARNING):
+            conn._negotiate_backslash_escapes()
+        assert conn._no_backslash_escapes is False
+        assert any("backslash-escape" in r.message for r in caplog.records)
+
+    def test_probe_none_row_falls_back_false_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        conn, _ = _make_sync_conn(None)
+        with caplog.at_level(logging.WARNING):
+            conn._negotiate_backslash_escapes()
+        assert conn._no_backslash_escapes is False
+        assert any("backslash-escape" in r.message for r in caplog.records)
+
+    def test_execute_error_falls_back_false_with_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        conn, _ = _make_sync_conn(None, raise_on_execute=True)
+        with caplog.at_level(logging.WARNING):
+            conn._negotiate_backslash_escapes()
+        assert conn._no_backslash_escapes is False
+        assert any("backslash-escape" in r.message for r in caplog.records)
+
+    def test_explicit_true_is_not_overridden(self) -> None:
+        conn, cur = _make_sync_conn((1,), preset=True)
+        conn._negotiate_backslash_escapes()
+        assert conn._no_backslash_escapes is True
+        cur.execute.assert_not_called()
+
+    def test_explicit_false_is_not_overridden(self) -> None:
+        conn, cur = _make_sync_conn((2,), preset=False)
+        conn._negotiate_backslash_escapes()
+        assert conn._no_backslash_escapes is False
+        cur.execute.assert_not_called()
+
+
+def _make_async_conn(
+    fetchone_result: object,
+    *,
+    preset: bool | None = None,
+    raise_on_execute: bool = False,
+) -> tuple[AsyncConnection, AsyncMock]:
+    conn = AsyncConnection.__new__(AsyncConnection)
+    conn._no_backslash_escapes = preset
+    mock_cursor = MagicMock()
+    if raise_on_execute:
+        mock_cursor.execute = AsyncMock(side_effect=RuntimeError("boom"))
+    else:
+        mock_cursor.execute = AsyncMock()
+    mock_cursor.fetchone = AsyncMock(return_value=fetchone_result)
+    mock_cursor.close = AsyncMock()
+    conn.cursor = MagicMock(return_value=mock_cursor)  # type: ignore[method-assign]
+    return conn, mock_cursor
+
+
+class TestAsyncNegotiation:
+    @pytest.mark.asyncio
+    async def test_probe_two_means_literal_mode(self) -> None:
+        conn, cur = _make_async_conn((2,))
+        await conn._negotiate_backslash_escapes()
+        assert conn._no_backslash_escapes is True
+        cur.execute.assert_awaited_once_with("SELECT CHAR_LENGTH('\\\\')")
+
+    @pytest.mark.asyncio
+    async def test_probe_one_means_escape_mode(self) -> None:
+        conn, _ = _make_async_conn((1,))
+        await conn._negotiate_backslash_escapes()
+        assert conn._no_backslash_escapes is False
+
+    @pytest.mark.asyncio
+    async def test_execute_error_falls_back_false(self) -> None:
+        conn, _ = _make_async_conn(None, raise_on_execute=True)
+        await conn._negotiate_backslash_escapes()
+        assert conn._no_backslash_escapes is False
+
+    @pytest.mark.asyncio
+    async def test_explicit_setting_is_not_overridden(self) -> None:
+        conn, cur = _make_async_conn((1,), preset=True)
+        await conn._negotiate_backslash_escapes()
+        assert conn._no_backslash_escapes is True
+        cur.execute.assert_not_awaited()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -316,8 +316,12 @@ class TestCursorAndAutocommit:
         )
         socket_queue.append(sock)
 
-        conn = Connection("localhost", 33000, "testdb", "dba", "", autocommit=True)
+        conn = Connection(
+            "localhost", 33000, "testdb", "dba", "", autocommit=True, no_backslash_escapes=False
+        )
 
+        # escape-mode negotiation is skipped via the explicit override so the
+        # mocked frame queue stays focused on the autocommit round-trip.
         assert conn.autocommit is True
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -455,3 +455,68 @@ class TestErrorHandling:
                 )
         finally:
             _drop_table(cursor, table_name)
+
+
+class TestBackslashRoundTrip:
+    """Round-trip integrity for string literals (issue #255).
+
+    On a stock CUBRID server (``no_backslash_escapes=yes``) a backslash is an
+    ordinary character.  These tests prove the auto-negotiated driver stores
+    and reads back each value byte-for-byte, and that ``%``/``_`` (LIKE
+    metacharacters, not string-literal escapes) are never mangled.
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            r"C:\temp\file",
+            "line1\nline2",
+            "tab\there",
+            "carriage\rreturn",
+            "50% off",
+            "a_b_c",
+            "don't",
+            r"back\slash and 'quote'",
+            r"regex \d+ pattern",
+            "plain unicode \ud55c\uad6d\uc5b4",
+        ],
+    )
+    def test_string_round_trip(self, cursor: Cursor, value: str) -> None:
+        table_name = _table_name("bslash")
+        try:
+            cursor.execute("CREATE TABLE %s (v VARCHAR(200))" % table_name)
+            cursor.execute("INSERT INTO %s (v) VALUES (?)" % table_name, (value,))
+            cursor.execute("SELECT v FROM %s" % table_name)
+            row = cursor.fetchone()
+            assert row is not None
+            assert row[0] == value
+        finally:
+            _drop_table(cursor, table_name)
+
+    def test_negotiated_mode_is_literal(self) -> None:
+        connection = pycubrid.connect(
+            host=TEST_HOST,
+            port=TEST_PORT,
+            database=TEST_DB,
+            user=TEST_USER,
+            password=TEST_PASSWORD,
+        )
+        try:
+            # Stock CUBRID defaults to no_backslash_escapes=yes -> literal mode.
+            assert connection._no_backslash_escapes is True
+        finally:
+            connection.close()
+
+    def test_explicit_override_is_respected(self) -> None:
+        connection = pycubrid.connect(
+            host=TEST_HOST,
+            port=TEST_PORT,
+            database=TEST_DB,
+            user=TEST_USER,
+            password=TEST_PASSWORD,
+            no_backslash_escapes=False,
+        )
+        try:
+            assert connection._no_backslash_escapes is False
+        finally:
+            connection.close()

--- a/tests/test_network_edge_cases.py
+++ b/tests/test_network_edge_cases.py
@@ -831,7 +831,9 @@ class TestAsyncPositiveRestoreOnReconnect:
         which would release-then-reacquire the lock)."""
         from pycubrid.protocol import CommitPacket, SetDbParameterPacket
 
-        conn = AsyncConnection("localhost", 33000, "testdb", "dba", "", autocommit=True)
+        conn = AsyncConnection(
+            "localhost", 33000, "testdb", "dba", "", autocommit=True, no_backslash_escapes=False
+        )
         sends: list[object] = []
 
         async def fake_connect_locked() -> None:
@@ -861,7 +863,9 @@ class TestAsyncPositiveRestoreOnReconnect:
     ) -> None:
         """A second (no-op) connect() call on an already-connected instance
         must not re-send SET_DB_PARAMETER."""
-        conn = AsyncConnection("localhost", 33000, "testdb", "dba", "", autocommit=True)
+        conn = AsyncConnection(
+            "localhost", 33000, "testdb", "dba", "", autocommit=True, no_backslash_escapes=False
+        )
         sends: list[object] = []
 
         async def fake_connect_locked() -> None:


### PR DESCRIPTION
## Summary
Fixes silent string corruption caused by an inverted `no_backslash_escapes` default (issue #255).

CUBRID's `no_backslash_escapes` system parameter **defaults to `yes`** — a backslash is an ordinary literal character, not an escape marker ([CUBRID manual](https://github.com/CUBRID/cubrid-manual/blob/master/en/sql/literal.rst): *"An escape using a backslash can be used if you set no_backslash_escapes in cubrid.conf as no. But this default value is yes."*). pycubrid, however, defaulted its client-side flag to `False` and unconditionally **doubled backslashes**, so against a stock server:

- `C:\temp\file` (12 chars) was stored as `C:\\temp\\file` (14 chars) — **corrupted**
- `regex \d+` became `regex \\d+` — **corrupted**

Reproduced live on a stock `cubrid:11.x` container before the fix.

## Fix
`Connection` / `AsyncConnection` now **auto-negotiate** the mode once at connect time when `no_backslash_escapes` is not passed explicitly, by probing the live server with `SELECT CHAR_LENGTH('\\')`:

| probe result | meaning | pinned value |
|---|---|---|
| `2` | server kept both backslashes → literal mode (CUBRID default) | `True` (no doubling) |
| `1` | server unescaped the pair → escape-processing mode | `False` |
| other / error | detection failed | `False` (legacy) + logged warning |

- Passing `no_backslash_escapes=True\|False` explicitly **skips** the probe (override honored).
- Negotiation is per physical connection and survives transparent reconnects.
- LIKE metacharacters (`%`, `_`) were never escaped and remain untouched.
- Detection failures never break `connect()`.

## Tests
- `tests/test_backslash_negotiation.py` — sync + async negotiation unit tests (probe=2/1/other/None/error, explicit override skips probe).
- `tests/test_integration.py::TestBackslashRoundTrip` — live round-trip of backslash paths, newlines, tabs, `%`, `_`, quotes, regex; asserts negotiated mode is literal and explicit override respected.
- Full suite: **1075 passed, 17 skipped**. `scripts/check_public_api.py`: **baseline unchanged**. ruff + mypy clean.

## Docs
- `docs/PARAMETER_BINDING.md` — reframed around auto-negotiation (was previously described as an exception mode); added an "Escape-mode negotiation" section.
- `CHANGELOG.md` — entry under `[Unreleased] → Fixed`.

## Release classification
Default value of `no_backslash_escapes` changed `False → None` (auto-negotiate). Per `RELEASE_POLICY.md` this is a permitted behavioral/default-value change → **minor (1.7.0)** at release time. Public API structural surface unchanged (compat-check passes).

## ⚠️ No merge — review only
Opening for review per maintainer instruction. Do not merge yet.

Closes #255