### PR TITLE
ci: adopt canonical PyPI publish workflow triggered by GitHub Release

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,12 +1,21 @@
+# Publish to PyPI via Trusted Publisher (OIDC) when a GitHub Release is published.
+#
+# Canonical cubrid-lab publish workflow — kept identical across pycubrid,
+# sqlalchemy-cubrid, and cubrid-mcp-server. Only the package/module name and the
+# smoke-test assertions differ between repos. Do not fork this structure without
+# updating the siblings.
+#
+# Trusted Publisher config:
+# https://pypi.org/manage/project/pycubrid/settings/publishing/
 name: Publish to PyPI
 
 on:
-  push:
-    tags: ['v*']
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag:
-        description: Git tag to publish (for example v0.5.1)
+        description: "Existing tag to (re)publish, e.g. v1.2.3"
         required: true
         type: string
 
@@ -14,31 +23,144 @@ permissions:
   contents: read
 
 jobs:
-  publish:
-    name: Build and publish
+  verify:
+    name: Build and verify release artifact
     runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          fetch-depth: 0
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.12"
+
+      - name: Extract version from __init__.py (AST, no import)
+        run: |
+          VERSION=$(python - <<'PY'
+          import ast, pathlib
+          tree = ast.parse(pathlib.Path("pycubrid/__init__.py").read_text())
+          print(next(
+              node.value.value
+              for node in ast.walk(tree)
+              if isinstance(node, ast.Assign)
+              for target in node.targets
+              if isinstance(target, ast.Name) and target.id == "__version__"
+          ))
+          PY
+          )
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+          echo "Detected package version: $VERSION"
+
+      - name: Resolve release tag
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "TAG=${{ inputs.tag }}" >> "$GITHUB_ENV"
+          else
+            echo "TAG=${{ github.event.release.tag_name }}" >> "$GITHUB_ENV"
+          fi
+
+      - name: Verify tag matches package version
+        run: |
+          if [ "$TAG" != "v$VERSION" ]; then
+            echo "::error::Release tag ($TAG) does not match package version (v$VERSION)"
+            exit 1
+          fi
+
+      - name: Verify CHANGELOG has a dated entry
+        run: |
+          if ! grep -qP "^## \[$VERSION\] - \d{4}-\d{2}-\d{2}" CHANGELOG.md; then
+            echo "::error::CHANGELOG.md missing dated entry '## [$VERSION] - YYYY-MM-DD'"
+            exit 1
+          fi
+          echo "CHANGELOG: $(grep -P "^## \[$VERSION\]" CHANGELOG.md | head -1)"
+
+      - name: Verify tag commit is contained in main
+        run: |
+          git fetch --no-tags --quiet origin main
+          TAG_COMMIT=$(git rev-list -n 1 "$TAG" 2>/dev/null || echo "")
+          if [ -z "$TAG_COMMIT" ]; then
+            echo "::error::Tag $TAG not found in repository"
+            exit 1
+          fi
+          if [ "${{ github.event_name }}" = "release" ]; then
+            TARGET="${{ github.event.release.target_commitish }}"
+            if git show-ref --verify --quiet "refs/remotes/origin/$TARGET"; then
+              TARGET=$(git rev-parse "origin/$TARGET")
+            fi
+            if [ "$TAG_COMMIT" != "$TARGET" ]; then
+              echo "::error::Tag $TAG points to $TAG_COMMIT but release targets $TARGET"
+              exit 1
+            fi
+          fi
+          if ! git merge-base --is-ancestor "$TAG_COMMIT" origin/main; then
+            echo "::error::Tag $TAG ($TAG_COMMIT) is not contained in origin/main"
+            exit 1
+          fi
+          echo "Tag $TAG commit $TAG_COMMIT verified on main"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+
+      - name: Check distribution metadata
+        run: |
+          twine check dist/*
+          shopt -s nullglob
+          matches=(dist/pycubrid-"$VERSION"*)
+          if [ ${#matches[@]} -eq 0 ]; then
+            echo "::error::Built artifacts do not carry version $VERSION"
+            ls -l dist/
+            exit 1
+          fi
+
+      - name: Smoke-test wheel install
+        run: |
+          python -m venv /tmp/wheel-env
+          /tmp/wheel-env/bin/pip install dist/*.whl
+          cd /tmp
+          /tmp/wheel-env/bin/python - <<'PY'
+          import os
+          import importlib.metadata as md
+          import pycubrid
+          expected = os.environ["VERSION"]
+          assert pycubrid.__version__ == expected, (pycubrid.__version__, expected)
+          assert md.version("pycubrid") == expected, (md.version("pycubrid"), expected)
+          print("wheel import + metadata OK:", expected)
+          PY
+
+      - name: Smoke-test sdist install
+        run: |
+          python -m venv /tmp/sdist-env
+          /tmp/sdist-env/bin/pip install dist/*.tar.gz
+          cd /tmp
+          /tmp/sdist-env/bin/python -c "import pycubrid; print('sdist import OK:', pycubrid.__version__)"
+
+      - name: Upload verified distribution
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pypi-dist
+          path: dist/
+          retention-days: 1
+          if-no-files-found: error
+
+  deploy:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: [verify]
     environment: pypi
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+      - name: Download verified distribution
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6
+          name: pypi-dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
         with:
-          python-version: "3.12"
-      - name: Check if tag matches __version__
-        run: |
-          TAG_NAME="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
-          VERSION_FROM_FILE=$(python -c "import pycubrid; print(pycubrid.__version__)")
-          TAG_VERSION=${TAG_NAME#v}
-          echo "Version from file: $VERSION_FROM_FILE"
-          echo "Tag name: $TAG_NAME"
-          echo "Version from tag: $TAG_VERSION"
-          if [ "$VERSION_FROM_FILE" != "$TAG_VERSION" ]; then
-            echo "::error ::Version in __init__.py ($VERSION_FROM_FILE) does not match git tag ($TAG_VERSION)"
-            exit 1
-          fi
-      - run: pip install build
-      - run: python -m build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+          attestations: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,20 +148,19 @@ Skipping any phase requires explicit justification. Trivial changes (typos, sing
 
 ## Release Process
 
-Version is tracked in TWO files — both MUST be updated together:
-- `pyproject.toml` → `version = "x.y.z"`
-- `pycubrid/__init__.py` → `__version__ = "x.y.z"`
+Version is single-sourced from `pycubrid/__init__.py` → `__version__ = "x.y.z"`.
+`pyproject.toml` derives it dynamically (`dynamic = ["version"]` + `version = {attr = "pycubrid.__version__"}`),
+so there is only one place to bump.
 
 Steps:
-1. `make release VERSION=x.y.z` (bumps both files, validates consistency)
-2. Add changelog entry in `CHANGELOG.md`
+1. `make release VERSION=x.y.z` (bumps `__init__.py`, validates)
+2. Add a dated changelog entry in `CHANGELOG.md` (`## [x.y.z] - YYYY-MM-DD`)
 3. Commit: `release: vx.y.z — <summary>`
-4. Tag: `git tag vx.y.z`
-5. Push with tags: `git push origin main --tags`
-6. Create GitHub release: `gh release create vx.y.z --title "..."`
-7. PyPI publish triggers automatically from tag push (`.github/workflows/publish-pypi.yml`)
-
-**CI enforces version consistency** — `pyproject.toml` version must match `__init__.py` `__version__` on every PR.
+4. Open a PR and merge to `main`
+5. Create a GitHub Release on the merged commit: `gh release create vx.y.z --title "..."`
+6. Publishing the GitHub Release triggers `.github/workflows/publish-pypi.yml`,
+   which rebuilds, verifies (tag == version, dated CHANGELOG, tag on main, smoke tests),
+   and publishes to PyPI via Trusted Publisher (OIDC).
 
 ## CI Matrix
 
@@ -171,7 +170,7 @@ Steps:
 |---|---|---|
 | `.github/workflows/ci.yml` | Push to main, PRs | Lint + offline tests (Py 3.10–3.14) + regular integration matrix |
 | `.github/workflows/integration-full.yml` | Nightly (03:00 UTC), tag push, manual dispatch | Full Python × CUBRID compatibility matrix |
-| `.github/workflows/publish-pypi.yml` | Tag push (`v*`) | Build and publish to PyPI |
+| `.github/workflows/publish-pypi.yml` | GitHub Release published | Build, verify, and publish to PyPI |
 
 ### Matrix Shape
 


### PR DESCRIPTION
## Summary
Unifies the PyPI publish workflow with the sibling repos (`sqlalchemy-cubrid`, `cubrid-mcp-server`) as **wave 1** of a two-wave rollout (this PR = workflow only; the actual release is a follow-up PR).

- Switch trigger from tag push (`v*`) to **GitHub Release published**.
- Split into `verify` → `deploy`: build sdist/wheel **once**, verify, upload as an artifact, then download and publish in an isolated `deploy` job (`environment: pypi`, OIDC). No rebuild before publishing.
- Read version via **AST** from `pycubrid/__init__.py` (no import side effects).
- Guards: tag == `__version__`, dated CHANGELOG entry, tag commit contained in `origin/main`.
- Smoke-test wheel + sdist in isolated venvs (asserts version and installed metadata).
- **Pin all actions to commit SHAs** (consistent with the other pycubrid workflows).
- Update `AGENTS.md` release process + CI matrix (Release trigger, single-source dynamic version).

## Verification
- `actionlint` passes (incl. shellcheck).

Docs: updated `AGENTS.md` release process and CI matrix in this PR.