### PR TITLE
chore: release v1.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [1.7.0] - 2026-09-02
+
 ### Documentation
 - **Added an Acknowledgments section and a `NOTICE` file crediting the CUBRID Node.js driver ([node-cubrid](https://github.com/CUBRID/node-cubrid), © 2008–2012 Search Solution Corporation, BSD-3-Clause)** — during pycubrid's initial development, node-cubrid was consulted as a reference implementation to understand CUBRID's CAS wire protocol (packet structure and function codes). This is recorded as an acknowledgment in `README.md`, `docs/README.ko.md`, and the new `NOTICE` file. Documentation only; no code or runtime behavior change.
 

--- a/pycubrid/__init__.py
+++ b/pycubrid/__init__.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
     from pycubrid.connection import Connection
     from pycubrid.timing import TimingStats
 
-__version__ = "1.6.2"
+__version__ = "1.7.0"
 
 # PEP 249 module-level attributes
 apilevel = "2.0"


### PR DESCRIPTION
## Summary
- Bump `pycubrid.__version__` to `1.7.0`
- Promote the Unreleased CHANGELOG entries under a dated `## [1.7.0] - 2026-09-02` heading

## Release
Merging this PR then publishing a GitHub Release `v1.7.0` will trigger `publish-pypi.yml` to build, verify, and publish to PyPI.